### PR TITLE
Correct author name of Error Code CI (Error Code Inspector).

### DIFF
--- a/weeklymeeting/20220930.md
+++ b/weeklymeeting/20220930.md
@@ -4,10 +4,10 @@
     - 刘建伟：remoting 30%-40% ——> 未同步
     - 刘泉禄：registry 70% ——> 暂无进展
     - 张翔：common 持续投入，缓存文件那块 ——> 暂无进展
+    - 张翔（已经移交）：ci  warn error 链接指向的检查 ——> done
     - 周林： protocol 20% ——> 暂无进展
     - 顾欣：cluster 100% ——> done
     - 赵俊宪：config 完成。统一code管理 ——> done
-    - 赵俊宪：ci  warn error 链接指向的检查 ——> done
     - ——> TODO
         - 剩余其它待处理的code @远云
 - Istio Agent 模式下的 Proxyless - 陈彦岚


### PR DESCRIPTION
修正 “ci  warn error 链接指向的检查” 的作者姓名。

对应项目：https://github.com/apache/dubbo-test-tools
相关 PR：https://github.com/apache/dubbo/pull/10680